### PR TITLE
Normalize webhook namespace selectors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,13 @@ jobs:
       run: make test
     - name: Report coverage
       uses: codecov/codecov-action@v3
+    - name: Disallow generated drift
+      run: |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        git diff --exit-code .
 
   stage:
     name: Stage

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -15,10 +15,10 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # $(SERVICE_NAME) and $(NAMESPACE) will be substituted by kustomize
   dnsNames:
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  - $(SERVICE_NAME).$(NAMESPACE).svc
+  - $(SERVICE_NAME).$(NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/config/crd/patches/cainjection_in_clusterworkloadresourcemappings.yaml
+++ b/config/crd/patches/cainjection_in_clusterworkloadresourcemappings.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATE_NAME)
   name: clusterworkloadresourcemappings.servicebinding.io

--- a/config/crd/patches/cainjection_in_servicebindings.yaml
+++ b/config/crd/patches/cainjection_in_servicebindings.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATE_NAME)
   name: servicebindings.servicebinding.io

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -49,29 +49,21 @@ patchesStrategicMerge:
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
 - name: CERTIFICATE_NAME
   objref:
     kind: Certificate
     group: cert-manager.io
     version: v1
     name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICE_NAMESPACE # namespace of the service
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
 - name: SERVICE_NAME
   objref:
     kind: Service
     version: v1
     name: webhook-service
+- name: NAMESPACE
+  objref:
+    kind: Namespace
+    version: v1
+    name: system
+  fieldref:
+    fieldpath: metadata.name

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,15 +1,15 @@
 # This patch add annotation to admission webhook config and
-# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+# the variables $(NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
 # apiVersion: admissionregistration.k8s.io/v1
 # kind: MutatingWebhookConfiguration
 # metadata:
 #   name: mutating-webhook-configuration
 #   annotations:
-#     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+#     cert-manager.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,6 +1,9 @@
 resources:
 - manager.yaml
 
+configurations:
+- kustomizeconfig.yaml
+
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/config/manager/kustomizeconfig.yaml
+++ b/config/manager/kustomizeconfig.yaml
@@ -1,0 +1,9 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution 
+varReference:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/namespaceSelector/matchExpressions/values
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/namespaceSelector/matchExpressions/values
+

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,15 +63,17 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: admission-projector
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATE_NAME)
     webhook.servicebinding.io/dynamic-rules: ""
 webhooks:
 - name: interceptor.servicebinding.io
   namespaceSelector:
     matchExpressions:
-    - key: control-plane
+    - key: kubernetes.io/metadata.name
       operator: NotIn
-      values: ["controller-manager"]
+      values:
+      - $(NAMESPACE)
+      - kube-system
   admissionReviewVersions: ["v1"]
   clientConfig:
     service:
@@ -88,15 +90,17 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: trigger
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATE_NAME)
     webhook.servicebinding.io/dynamic-rules: ""
 webhooks:
 - name: trigger.servicebinding.io
   namespaceSelector:
     matchExpressions:
-    - key: control-plane
+    - key: kubernetes.io/metadata.name
       operator: NotIn
-      values: ["controller-manager"]
+      values:
+      - $(NAMESPACE)
+      - kube-system
   admissionReviewVersions: ["v1"]
   clientConfig:
     service:

--- a/config/servicebinding-runtime.yaml
+++ b/config/servicebinding-runtime.yaml
@@ -747,10 +747,11 @@ webhooks:
   name: interceptor.servicebinding.io
   namespaceSelector:
     matchExpressions:
-    - key: control-plane
+    - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
-      - controller-manager
+      - servicebinding-runtime-system
+      - kube-system
   reinvocationPolicy: IfNeeded
   sideEffects: None
 ---
@@ -773,10 +774,11 @@ webhooks:
   name: trigger.servicebinding.io
   namespaceSelector:
     matchExpressions:
-    - key: control-plane
+    - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
-      - controller-manager
+      - servicebinding-runtime-system
+      - kube-system
   reinvocationPolicy: Never
   sideEffects: None
 ---


### PR DESCRIPTION
Ignore the servicebinding-runtime-system and kube-system namespaces
for the interceptor and trigger webhooks using a namespace selector.
This PR also normalizes the kustomize *_NAMESPACE vars into a single
NAMESPACE var.

Signed-off-by: Scott Andrews <scott@andrews.me>