### PR TITLE
Upgrade reconciler-runtime to 0.7.1

### DIFF
--- a/config/rbac/clusterworkloadresourcemapping_editor_role.yaml
+++ b/config/rbac/clusterworkloadresourcemapping_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clusterworkloadresourcemapping-editor-role
 rules:
 - apiGroups:
-  - servicebinservicebinding.io
+  - servicebinding.io
   resources:
   - clusterworkloadresourcemappings
   verbs:

--- a/controllers/servicebinding_controller_test.go
+++ b/controllers/servicebinding_controller_test.go
@@ -19,7 +19,6 @@ package controllers_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	dieappsv1 "dies.dev/apis/apps/v1"
 	diecorev1 "dies.dev/apis/core/v1"
@@ -62,7 +61,6 @@ func TestServiceBindingReconciler(t *testing.T) {
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Namespace(namespace)
 			d.Name(name)
-			d.ResourceVersion("999")
 			d.UID(uid)
 		}).
 		SpecDie(func(d *dieservicebindingv1beta1.ServiceBindingSpecDie) {
@@ -86,8 +84,6 @@ func TestServiceBindingReconciler(t *testing.T) {
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Namespace(namespace)
 			d.Name("my-workload")
-			d.CreationTimestamp(now)
-			d.ResourceVersion("999")
 		}).
 		SpecDie(func(d *dieappsv1.DeploymentSpecDie) {
 			d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
@@ -279,7 +275,6 @@ func TestResolveBindingSecret(t *testing.T) {
 	notProvisionedService.SetKind("MyProvisionedService")
 	notProvisionedService.SetNamespace(namespace)
 	notProvisionedService.SetName("my-service")
-	notProvisionedService.SetResourceVersion("999")
 	provisionedService := notProvisionedService.DeepCopy()
 	provisionedService.UnstructuredContent()["status"] = map[string]interface{}{
 		"binding": map[string]interface{}{
@@ -451,11 +446,7 @@ func TestResolveWorkload(t *testing.T) {
 
 	workload := dieappsv1.DeploymentBlank.
 		APIVersion("apps/v1").
-		Kind("Deployment").
-		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
-			d.ResourceVersion("999")
-			d.CreationTimestamp(metav1.NewTime(time.UnixMilli(1000)))
-		})
+		Kind("Deployment")
 	workload1 := workload.
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Namespace(namespace)
@@ -679,7 +670,6 @@ func TestProjectBinding(t *testing.T) {
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Namespace(namespace)
 			d.Name(name)
-			d.ResourceVersion("999")
 			d.UID(uid)
 		}).
 		SpecDie(func(d *dieservicebindingv1beta1.ServiceBindingSpecDie) {
@@ -704,7 +694,6 @@ func TestProjectBinding(t *testing.T) {
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Namespace(namespace)
 			d.Name("my-workload")
-			d.ResourceVersion("999")
 		}).
 		SpecDie(func(d *dieappsv1.DeploymentSpecDie) {
 			d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
@@ -830,7 +819,6 @@ func TestPatchWorkloads(t *testing.T) {
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Namespace(namespace)
 			d.Name(name)
-			d.CreationTimestamp(now)
 		}).
 		StatusDie(func(d *dieservicebindingv1beta1.ServiceBindingStatusDie) {
 			d.ConditionsDie(
@@ -849,7 +837,6 @@ func TestPatchWorkloads(t *testing.T) {
 			d.Namespace(namespace)
 			d.Name("my-workload")
 			d.CreationTimestamp(now)
-			d.ResourceVersion("999")
 			d.UID(uid)
 		}).
 		SpecDie(func(d *dieappsv1.DeploymentSpecDie) {

--- a/controllers/webhook_controller_test.go
+++ b/controllers/webhook_controller_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	dieadmissionv1 "dies.dev/apis/admission/v1"
 	dieadmissionregistrationv1 "dies.dev/apis/admissionregistration/v1"
@@ -62,8 +61,6 @@ func TestAdmissionProjectorReconciler(t *testing.T) {
 	name := "my-webhook"
 	key := types.NamespacedName{Name: name}
 
-	now := metav1.Now().Rfc3339Copy()
-
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(servicebindingv1beta1.AddToScheme(scheme))
@@ -71,7 +68,6 @@ func TestAdmissionProjectorReconciler(t *testing.T) {
 	webhook := dieadmissionregistrationv1.MutatingWebhookConfigurationBlank.
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Name(name)
-			d.CreationTimestamp(now)
 		}).
 		WebhookDie("projector.servicebinding.io", func(d *dieadmissionregistrationv1.MutatingWebhookDie) {
 			d.ClientConfigDie(func(d *dieadmissionregistrationv1.WebhookClientConfigDie) {
@@ -497,8 +493,6 @@ func TestTriggerReconciler(t *testing.T) {
 	name := "my-webhook"
 	key := types.NamespacedName{Name: name}
 
-	now := metav1.Now().Rfc3339Copy()
-
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(servicebindingv1beta1.AddToScheme(scheme))
@@ -506,7 +500,6 @@ func TestTriggerReconciler(t *testing.T) {
 	webhook := dieadmissionregistrationv1.ValidatingWebhookConfigurationBlank.
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Name(name)
-			d.CreationTimestamp(now)
 		}).
 		WebhookDie("trigger.servicebinding.io", func(d *dieadmissionregistrationv1.ValidatingWebhookDie) {
 			d.ClientConfigDie(func(d *dieadmissionregistrationv1.WebhookClientConfigDie) {
@@ -754,8 +747,6 @@ func TestLoadServiceBindings(t *testing.T) {
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Namespace("my-namespace")
 			d.Name("my-binding")
-			d.ResourceVersion("999")
-			d.CreationTimestamp(metav1.NewTime(time.UnixMilli(1000)))
 		}).
 		SpecDie(func(d *dieservicebindingv1beta1.ServiceBindingSpecDie) {
 			d.ServiceDie(func(d *dieservicebindingv1beta1.ServiceBindingServiceReferenceDie) {
@@ -810,7 +801,6 @@ func TestInterceptGVKs(t *testing.T) {
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Namespace("my-namespace")
 			d.Name("my-binding")
-			d.ResourceVersion("999")
 		}).
 		SpecDie(func(d *dieservicebindingv1beta1.ServiceBindingSpecDie) {
 			d.ServiceDie(func(d *dieservicebindingv1beta1.ServiceBindingServiceReferenceDie) {
@@ -873,7 +863,6 @@ func TestTriggerGVKs(t *testing.T) {
 		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 			d.Namespace("my-namespace")
 			d.Name("my-binding")
-			d.ResourceVersion("999")
 		}).
 		SpecDie(func(d *dieservicebindingv1beta1.ServiceBindingSpecDie) {
 			d.ServiceDie(func(d *dieservicebindingv1beta1.ServiceBindingServiceReferenceDie) {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	dies.dev v0.5.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8
-	github.com/vmware-labs/reconciler-runtime v0.7.0
+	github.com/vmware-labs/reconciler-runtime v0.7.1
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/vmware-labs/reconciler-runtime v0.7.0 h1:UskRZtfqlZxBTcULA/jSic+E/0XF4jmnHTMsxa6X3cQ=
-github.com/vmware-labs/reconciler-runtime v0.7.0/go.mod h1:pNWkfKJzNJ1j2m6g3PeBIM9uy4KaUWNXYqAf6SqR+b4=
+github.com/vmware-labs/reconciler-runtime v0.7.1 h1:CH7yzD2dQsCKFmICqXhmE9vS9B84ogY3W6tl6wJgJ9Y=
+github.com/vmware-labs/reconciler-runtime v0.7.1/go.mod h1:pNWkfKJzNJ1j2m6g3PeBIM9uy4KaUWNXYqAf6SqR+b4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/resolver/cluster_test.go
+++ b/resolver/cluster_test.go
@@ -456,10 +456,8 @@ func TestClusterResolver_LookupWorkloads(t *testing.T) {
 						"apiVersion": "apps/v1",
 						"kind":       "Deployment",
 						"metadata": map[string]interface{}{
-							"name":              "my-workload",
-							"namespace":         "my-namespace",
-							"creationTimestamp": "1970-01-01T00:00:01Z",
-							"resourceVersion":   "999",
+							"name":      "my-workload",
+							"namespace": "my-namespace",
 						},
 						"spec": map[string]interface{}{
 							"selector": nil,
@@ -504,16 +502,13 @@ func TestClusterResolver_LookupWorkloads(t *testing.T) {
 						"apiVersion": "workload.local/v1",
 						"kind":       "MyWorkload",
 						"metadata": map[string]interface{}{
-							"name":              "my-workload",
-							"namespace":         "my-namespace",
-							"creationTimestamp": "1970-01-01T00:00:01Z",
-							"resourceVersion":   "999",
+							"name":      "my-workload",
+							"namespace": "my-namespace",
 						},
 					},
 				},
 			},
 		},
-
 		{
 			name: "list workloads from scheme",
 			givenObjects: []client.Object{
@@ -566,8 +561,6 @@ func TestClusterResolver_LookupWorkloads(t *testing.T) {
 							"labels": map[string]interface{}{
 								"app": "my",
 							},
-							"creationTimestamp": "1970-01-01T00:00:01Z",
-							"resourceVersion":   "999",
 						},
 						"spec": map[string]interface{}{
 							"selector": nil,
@@ -594,8 +587,6 @@ func TestClusterResolver_LookupWorkloads(t *testing.T) {
 							"labels": map[string]interface{}{
 								"app": "my",
 							},
-							"creationTimestamp": "1970-01-01T00:00:01Z",
-							"resourceVersion":   "999",
 						},
 						"spec": map[string]interface{}{
 							"selector": nil,
@@ -678,8 +669,6 @@ func TestClusterResolver_LookupWorkloads(t *testing.T) {
 							"labels": map[string]interface{}{
 								"app": "my",
 							},
-							"creationTimestamp": "1970-01-01T00:00:01Z",
-							"resourceVersion":   "999",
 						},
 					},
 				},
@@ -693,8 +682,6 @@ func TestClusterResolver_LookupWorkloads(t *testing.T) {
 							"labels": map[string]interface{}{
 								"app": "my",
 							},
-							"creationTimestamp": "1970-01-01T00:00:01Z",
-							"resourceVersion":   "999",
 						},
 					},
 				},
@@ -720,7 +707,7 @@ func TestClusterResolver_LookupWorkloads(t *testing.T) {
 			if c.expectedErr {
 				return
 			}
-			if diff := cmp.Diff(c.expected, actual); diff != "" {
+			if diff := cmp.Diff(c.expected, actual, rtesting.IgnoreResourceVersion, rtesting.IgnoreCreationTimestamp); diff != "" {
 				t.Errorf("LookupWorkloads() (-expected, +actual): %s", diff)
 			}
 		})


### PR DESCRIPTION
Drops redundant definitions of resource version and creation timestamp.

Signed-off-by: Scott Andrews <scott@andrews.me>